### PR TITLE
Github secrets Docker production

### DIFF
--- a/.github/workflows/run-docker-prod.yml
+++ b/.github/workflows/run-docker-prod.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       MONGO_URL: ${{ secrets.MONGO_URL }}
+      SECRET: ${{ secrets.SECRET || secrets.secret }}
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Pass GitHub secret `secret` to Docker Compose in production.

The `docker-compose.yml` for the `app-prod` service expects a `SECRET` environment variable, but the workflow was not exporting it. This change ensures the secret is available to the container at runtime.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-4c1a8c6a-580c-415b-aa92-9e69e1f58238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c1a8c6a-580c-415b-aa92-9e69e1f58238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

